### PR TITLE
Added conditional get support for client script middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "keywords": [],
-  "dependencies": {}
+  "dependencies": {
+    "etag": "^1.7.0",
+    "fresh": "^0.3.0"
+  }
 }

--- a/test/middleware/middleware.js
+++ b/test/middleware/middleware.js
@@ -19,10 +19,47 @@ describe("Using the middleware", function () {
         assert.isFunction(index.middleware);
     });
 
-    it("should return the JS", function (done) {
+    it("should return the JS when no cache", function (done) {
         request(app)
             .get("/client")
             .expect("Content-Type", /text\/javascript/)
+            .expect("Cache-Control", "public, max-age=0")
+            .expect("ETag", /".*-.*"/)
+            .expect(200)
+            .end(function (err, res) {
+                assert.isTrue(res.text.length > 0);
+                assert.isTrue(res.text.indexOf("BEFORE") > -1);
+                done();
+            });
+    });
+
+    it("should return not modified if has cache and fresh", function (done) {
+        var etag = null;
+        request(app)
+            .get("/client")
+            .end(function (err, res) {
+                etag = res.headers["ETag"];
+            });
+
+        request(app)
+            .get("/client")
+            .set("If-None-Match", etag)
+            .expect("Cache-Control", "public, max-age=0")
+            .expect("ETag", /".*-.*"/)
+            .expect(304)
+            .end(function (err, res) {
+                assert.isUndefined(res.headers["Content-Type"]);
+                done();
+            });
+    });
+
+    it("should return the JS if has cache and not fresh", function (done) {
+        request(app)
+            .get("/client")
+            .set("If-None-Match", "Different-ETag")
+            .expect("Content-Type", /text\/javascript/)
+            .expect("Cache-Control", "public, max-age=0")
+            .expect("ETag", /".*-.*"/)
             .expect(200)
             .end(function (err, res) {
                 assert.isTrue(res.text.length > 0);


### PR DESCRIPTION
The client script is now served conditionally based on the request headers. This means that if the browser sends a conditional request and the current body is fresh, we send a not modified response. Otherwise, we send the request as usual.

Note that I get inspiration from the [send](https://github.com/pillarjs/send) package (which in fact I tried to use in my first draft). But most of the stuff we need are in private APIs but we might think about re-using them anyway.

This is complete from my point of view, simply missing your input.