### PR TITLE
Simplify hack for Chrome repaint issue.

### DIFF
--- a/lib/code-sync.js
+++ b/lib/code-sync.js
@@ -22,7 +22,6 @@ var options = {
     }
 };
 
-var hiddenElem;
 var OPT_PATH = "codeSync";
 
 var current = function () {
@@ -146,16 +145,8 @@ sync.swapFile = function (elem, attr, options) {
 
     elem[attr] = currentValue + suffix;
 
-    var body = document.body;
-
     setTimeout(function () {
-        if (!hiddenElem) {
-            hiddenElem = document.createElement("DIV");
-            body.appendChild(hiddenElem);
-        } else {
-            hiddenElem.style.display = "none";
-            hiddenElem.style.display = "block";
-        }
+        document.body.offsetWidth;
     }, 200);
 
     return {

--- a/lib/code-sync.js
+++ b/lib/code-sync.js
@@ -146,7 +146,7 @@ sync.swapFile = function (elem, attr, options) {
     elem[attr] = currentValue + suffix;
 
     setTimeout(function () {
-        document.body.offsetWidth;
+        document.body.offsetWidth; // jshint ignore:line
     }, 200);
 
     return {


### PR DESCRIPTION
Asking for the dimensions of an element is enough to trigger a repaint (with the updated the stylesheet). No need to create a hidden element and change it’s display.