### PR TITLE
Only remove notify element if it is attached to the dom

### DIFF
--- a/lib/notify.js
+++ b/lib/notify.js
@@ -97,7 +97,9 @@ exports.flash = function (message, timeout) {
 
     timeoutInt = window.setTimeout(function () {
         elem.style.display = "none";
-        $body.removeChild(elem);
+        if (elem.parentNode) {
+            $body.removeChild(elem);
+        }
     }, timeout || 2000);
 
     return elem;


### PR DESCRIPTION
After b537c7863fea0d88d5794a013bb11de983606d01, I'm seeing a lot of this:
```
Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

This is in cases where the notify element has been removed from the body by other means (e.g. React rendering to the body).

This change makes it so the child is only removed if it has a parent.
