### PR TITLE
Change the raw scroll value being emitted from an object ({x,y}) to a number (y)

### DIFF
--- a/lib/ghostmode.scroll.js
+++ b/lib/ghostmode.scroll.js
@@ -68,7 +68,7 @@ exports.socketEvent = function (bs) {
         if (bs.options && bs.options.scrollProportionally) {
             return window.scrollTo(0, scrollSpace.y * data.position.proportional); // % of y axis of scroll to px
         } else {
-            return window.scrollTo(0, data.position.raw);
+            return window.scrollTo(0, data.position.raw.y);
         }
     };
 };
@@ -141,7 +141,7 @@ exports.browserEvent = function (bs) {
 exports.getScrollPosition = function () {
     var pos = utils.getBrowserScrollPosition();
     return {
-        raw: pos.y, // Get px of y axis of scroll
+        raw: pos, // Get px of x and y axis of scroll
         proportional: exports.getScrollTopPercentage(pos) // Get % of y axis of scroll
     };
 };

--- a/lib/ghostmode.scroll.js
+++ b/lib/ghostmode.scroll.js
@@ -141,7 +141,7 @@ exports.browserEvent = function (bs) {
 exports.getScrollPosition = function () {
     var pos = utils.getBrowserScrollPosition();
     return {
-        raw: pos, // Get px of y axis of scroll
+        raw: pos.y, // Get px of y axis of scroll
         proportional: exports.getScrollTopPercentage(pos) // Get % of y axis of scroll
     };
 };

--- a/test/client-new/ghostmode.scroll.js
+++ b/test/client-new/ghostmode.scroll.js
@@ -34,7 +34,7 @@ describe("The scroll Plugin", function () {
     });
     it("socketEvent(): 1", function () {
         var stub = sinon.stub(window, "scrollTo");
-        scroll.socketEvent(bs)({position: {raw: 100}});
+        scroll.socketEvent(bs)({position: {raw: {x: 0, y:100}}});
         sinon.assert.calledWithExactly(stub, 0, 100);
         stub.restore();
     });
@@ -68,7 +68,10 @@ describe("The scroll Plugin", function () {
         before(function () {
             stub   = sinon.stub(scroll, "getScrollPosition").returns({
                 proportional: 0.5,
-                raw: 100
+                raw: {
+                    x: 0,
+                    y: 100
+                }
             });
         });
         afterEach(function () {
@@ -86,7 +89,10 @@ describe("The scroll Plugin", function () {
             sinon.assert.calledWithExactly(spy, "scroll", {
                 position: {
                     proportional: 0.5,
-                    raw: 100
+                    raw: {
+                        x: 0,
+                        y: 100
+                    }
                 }
             });
         });


### PR DESCRIPTION
"non-proportional" (`scrollProportionally = false`) scroll sync doesn't work. That's because `window.scrollTo` is being called (`window.scrollTo(0, data.position.raw)`) incorrectly with an object (`data.position.raw = {x, y}`) and not a number (as [tests suggest](https://github.com/BrowserSync/browser-sync-client/blob/master/test/client-new/ghostmode.scroll.js#L71)). This PR fixes that.

Fixes #16 
