### PR TITLE
Keeping url params to avoid dynamic css's errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -441,12 +441,19 @@ sync.swapFile = function (elem, attr, options) {
 
     var currentValue = elem[attr];
     var timeStamp = new Date().getTime();
-    var suffix = "?rel=" + timeStamp;
+    var suffix = "rel=" + timeStamp;
 
+    var justParams = sync.getParamsOnly(currentValue);
     var justUrl = sync.getFilenameOnly(currentValue);
 
     if (justUrl) {
         currentValue = justUrl[0];
+    }
+
+    if (justParams !== "") {
+        suffix = justParams[justParams.length -1] === "&" ? suffix : "&" + suffix;
+    } else {
+        suffix = "?" + suffix;
     }
 
     if (options) {
@@ -455,7 +462,7 @@ sync.swapFile = function (elem, attr, options) {
         }
     }
 
-    elem[attr] = currentValue + suffix;
+    elem[attr] = currentValue + justParams + suffix;
 
     var body = document.body;
 
@@ -473,6 +480,11 @@ sync.swapFile = function (elem, attr, options) {
         elem: elem,
         timeStamp: timeStamp
     };
+};
+
+sync.getParamsOnly = function (url) {
+    var buf = url.match(/[(\?|\&)]([^=]+)\=([^&#]+)/g);
+    return buf ? buf.join("").replace(/rel=([0-9]+)/g, "").replace("&&", "&") : "";
 };
 
 sync.getFilenameOnly = function (url) {
@@ -584,6 +596,7 @@ sync.reloadBrowser = function (confirm) {
         utils.reloadBrowser();
     }
 };
+
 },{"./browser.utils":2,"./emitter":5,"./events":6}],5:[function(require,module,exports){
 "use strict";
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -276,6 +276,46 @@ utils.forEach = function (coll, fn) {
 utils.isOldIe = function () {
     return typeof utils.getWindow().attachEvent !== "undefined";
 };
+
+
+/**
+ * Split the URL information
+ * @returns {object}
+ */
+utils.getLocation = function (url) {
+    var location = utils.getDocument().createElement("a");
+    location.href = url;
+
+    if (location.host === "") {
+        location.href = location.href;
+    }
+
+    return location;
+};
+
+/**
+ * Remove a param from URL
+ * http://stackoverflow.com/questions/16941104/remove-a-parameter-to-the-url-with-javascript
+ * @returns {object}
+ */
+utils.removeParam = function (key, url) {
+    var rtn = url.split("?")[0],
+        param,
+        params_arr = [],
+        queryString = (url.indexOf("?") !== -1) ? url.split("?")[1] : "";
+    if (queryString !== "") {
+        params_arr = queryString.split("&");
+        for (var i = params_arr.length - 1; i >= 0; i -= 1) {
+            param = params_arr[i].split("=")[0];
+            if (param === key) {
+                params_arr.splice(i, 1);
+            }
+        }
+        rtn = rtn + "?" + params_arr.join("&");
+    }
+    return rtn;
+};
+
 },{}],3:[function(require,module,exports){
 if (!("indexOf" in Array.prototype)) {
 
@@ -437,55 +477,53 @@ sync.saveScrollInCookie = function ($window, $document) {
  * @param options
  * @returns {{elem: HTMLElement, timeStamp: number}}
  */
-sync.swapFile = function (elem, attr, options) {
+ sync.swapFile = function (elem, attr, options) {
 
-    var currentValue = elem[attr];
-    var timeStamp = new Date().getTime();
-    var suffix = "rel=" + timeStamp;
+     var currentValue = elem[attr];
+     var timeStamp = new Date().getTime();
+     var suffix = "rel=" + timeStamp;
 
-    var justParams = sync.getParamsOnly(currentValue);
-    var justUrl = sync.getFilenameOnly(currentValue);
+     var justParams = utils.getLocation(currentValue).search;
+     var justUrl = sync.getFilenameOnly(currentValue);
 
-    if (justUrl) {
-        currentValue = justUrl[0];
-    }
+     // removing the rel param
+     justParams = utils.removeParam("rel", justParams);
 
-    if (justParams !== "") {
-        suffix = justParams[justParams.length -1] === "&" ? suffix : "&" + suffix;
-    } else {
-        suffix = "?" + suffix;
-    }
+     if (justUrl) {
+         currentValue = justUrl[0];
+     }
 
-    if (options) {
-        if (!options.timestamps) {
-            suffix = "";
-        }
-    }
+     if (justParams !== "") {
+         suffix = justParams[justParams.length -1] === "&" ? suffix : "&" + suffix;
+     } else {
+         suffix = "?" + suffix;
+     }
 
-    elem[attr] = currentValue + justParams + suffix;
+     if (options) {
+         if (!options.timestamps) {
+             suffix = "";
+         }
+     }
 
-    var body = document.body;
+     elem[attr] = currentValue + justParams + suffix;
 
-    setTimeout(function () {
-        if (!hiddenElem) {
-            hiddenElem = document.createElement("DIV");
-            body.appendChild(hiddenElem);
-        } else {
-            hiddenElem.style.display = "none";
-            hiddenElem.style.display = "block";
-        }
-    }, 200);
+     var body = document.body;
 
-    return {
-        elem: elem,
-        timeStamp: timeStamp
-    };
-};
+     setTimeout(function () {
+         if (!hiddenElem) {
+             hiddenElem = document.createElement("DIV");
+             body.appendChild(hiddenElem);
+         } else {
+             hiddenElem.style.display = "none";
+             hiddenElem.style.display = "block";
+         }
+     }, 200);
 
-sync.getParamsOnly = function (url) {
-    var buf = url.match(/[(\?|\&)]([^=]+)\=([^&#]+)/g);
-    return buf ? buf.join("").replace(/rel=([0-9]+)/g, "").replace("&&", "&") : "";
-};
+     return {
+         elem: elem,
+         timeStamp: timeStamp
+     };
+ };
 
 sync.getFilenameOnly = function (url) {
     return /^[^\?]+(?=\?)/.exec(url);

--- a/lib/browser.utils.js
+++ b/lib/browser.utils.js
@@ -179,7 +179,7 @@ utils.getLocation = function (url) {
 /**
  * Remove a param from URL
  * http://stackoverflow.com/questions/16941104/remove-a-parameter-to-the-url-with-javascript
- * @returns {object}
+ * @returns {string} url
  */
 utils.removeParam = function (key, url) {
     var rtn = url.split("?")[0],

--- a/lib/browser.utils.js
+++ b/lib/browser.utils.js
@@ -159,3 +159,42 @@ utils.forEach = function (coll, fn) {
 utils.isOldIe = function () {
     return typeof utils.getWindow().attachEvent !== "undefined";
 };
+
+
+/**
+ * Split the URL information
+ * @returns {object}
+ */
+utils.getLocation = function (url) {
+    var location = utils.getDocument().createElement("a");
+    location.href = url;
+
+    if (location.host === "") {
+        location.href = location.href;
+    }
+
+    return location;
+};
+
+/**
+ * Remove a param from URL
+ * http://stackoverflow.com/questions/16941104/remove-a-parameter-to-the-url-with-javascript
+ * @returns {object}
+ */
+utils.removeParam = function (key, url) {
+    var rtn = url.split("?")[0],
+        param,
+        params_arr = [],
+        queryString = (url.indexOf("?") !== -1) ? url.split("?")[1] : "";
+    if (queryString !== "") {
+        params_arr = queryString.split("&");
+        for (var i = params_arr.length - 1; i >= 0; i -= 1) {
+            param = params_arr[i].split("=")[0];
+            if (param === key) {
+                params_arr.splice(i, 1);
+            }
+        }
+        rtn = rtn + "?" + params_arr.join("&");
+    }
+    return rtn;
+};

--- a/lib/code-sync.js
+++ b/lib/code-sync.js
@@ -141,12 +141,19 @@ sync.swapFile = function (elem, attr, options) {
 
     var currentValue = elem[attr];
     var timeStamp = new Date().getTime();
-    var suffix = "?rel=" + timeStamp;
+    var suffix = "rel=" + timeStamp;
 
+    var justParams = sync.getParamsOnly(currentValue);
     var justUrl = sync.getFilenameOnly(currentValue);
 
     if (justUrl) {
         currentValue = justUrl[0];
+    }
+
+    if (justParams !== "") {
+        suffix = justParams[justParams.length -1] === "&" ? suffix : "&" + suffix;
+    } else {
+        suffix = "?" + suffix;
     }
 
     if (options) {
@@ -155,7 +162,7 @@ sync.swapFile = function (elem, attr, options) {
         }
     }
 
-    elem[attr] = currentValue + suffix;
+    elem[attr] = currentValue + justParams + suffix;
 
     var body = document.body;
 
@@ -173,6 +180,11 @@ sync.swapFile = function (elem, attr, options) {
         elem: elem,
         timeStamp: timeStamp
     };
+};
+
+sync.getParamsOnly = function (url) {
+    var buf = url.match(/[(\?|\&)]([^=]+)\=([^&#]+)/g);
+    return buf ? buf.join("").replace(/rel=([0-9]+)/g, "").replace("&&", "&") : "";
 };
 
 sync.getFilenameOnly = function (url) {

--- a/lib/code-sync.js
+++ b/lib/code-sync.js
@@ -137,55 +137,53 @@ sync.saveScrollInCookie = function ($window, $document) {
  * @param options
  * @returns {{elem: HTMLElement, timeStamp: number}}
  */
-sync.swapFile = function (elem, attr, options) {
+ sync.swapFile = function (elem, attr, options) {
 
-    var currentValue = elem[attr];
-    var timeStamp = new Date().getTime();
-    var suffix = "rel=" + timeStamp;
+     var currentValue = elem[attr];
+     var timeStamp = new Date().getTime();
+     var suffix = "rel=" + timeStamp;
 
-    var justParams = sync.getParamsOnly(currentValue);
-    var justUrl = sync.getFilenameOnly(currentValue);
+     var justParams = utils.getLocation(currentValue).search;
+     var justUrl = sync.getFilenameOnly(currentValue);
 
-    if (justUrl) {
-        currentValue = justUrl[0];
-    }
+     // removing the rel param
+     justParams = utils.removeParam("rel", justParams);
 
-    if (justParams !== "") {
-        suffix = justParams[justParams.length -1] === "&" ? suffix : "&" + suffix;
-    } else {
-        suffix = "?" + suffix;
-    }
+     if (justUrl) {
+         currentValue = justUrl[0];
+     }
 
-    if (options) {
-        if (!options.timestamps) {
-            suffix = "";
-        }
-    }
+     if (justParams !== "") {
+         suffix = justParams[justParams.length -1] === "&" ? suffix : "&" + suffix;
+     } else {
+         suffix = "?" + suffix;
+     }
 
-    elem[attr] = currentValue + justParams + suffix;
+     if (options) {
+         if (!options.timestamps) {
+             suffix = "";
+         }
+     }
 
-    var body = document.body;
+     elem[attr] = currentValue + justParams + suffix;
 
-    setTimeout(function () {
-        if (!hiddenElem) {
-            hiddenElem = document.createElement("DIV");
-            body.appendChild(hiddenElem);
-        } else {
-            hiddenElem.style.display = "none";
-            hiddenElem.style.display = "block";
-        }
-    }, 200);
+     var body = document.body;
 
-    return {
-        elem: elem,
-        timeStamp: timeStamp
-    };
-};
+     setTimeout(function () {
+         if (!hiddenElem) {
+             hiddenElem = document.createElement("DIV");
+             body.appendChild(hiddenElem);
+         } else {
+             hiddenElem.style.display = "none";
+             hiddenElem.style.display = "block";
+         }
+     }, 200);
 
-sync.getParamsOnly = function (url) {
-    var buf = url.match(/[(\?|\&)]([^=]+)\=([^&#]+)/g);
-    return buf ? buf.join("").replace(/rel=([0-9]+)/g, "").replace("&&", "&") : "";
-};
+     return {
+         elem: elem,
+         timeStamp: timeStamp
+     };
+ };
 
 sync.getFilenameOnly = function (url) {
     return /^[^\?]+(?=\?)/.exec(url);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-sync-client",
   "description": "Client-side scripts for BrowserSync",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "homepage": "https://github.com/shakyshane/browser-sync-client",
   "author": {
     "name": "Shane Osbourne",


### PR DESCRIPTION
Some applications uses dynamic css files with query params like the following line:
```
styles.css?modules=a|b|d|r
```
Keeping the query params will ensure the operation of these files. 

The **rel** param is removed if exists on the current url and added at the end of the new url.
