### PR TITLE
Improving getMatches

### DIFF
--- a/lib/code-sync.js
+++ b/lib/code-sync.js
@@ -270,9 +270,10 @@ sync.getMatches = function (elems, url, attr) {
     }
 
     var matches = [];
+    var urlMatcher = new RegExp("(^|/)" + url);
 
     for (var i = 0, len = elems.length; i < len; i += 1) {
-        if (elems[i][attr].indexOf(url) !== -1) {
+        if (urlMatcher.test(elems[i][attr])) {
             matches.push(elems[i]);
         }
     }

--- a/test/client-new/code-sync.js
+++ b/test/client-new/code-sync.js
@@ -160,7 +160,10 @@ describe("Code Sync", function () {
 
     describe("matching elements", function () {
 
-        var stubs = [
+        var stubs;
+
+        beforeEach(function() {
+            stubs = [
             {
                 id: "stub1",
                 href: "http://localhost:8080/style.css"
@@ -174,6 +177,8 @@ describe("Code Sync", function () {
                 href: "http://localhost:8080/stee/erqq/qefrerf/erferf/style-with-paths.css"
             }
         ];
+
+        });
 
         it("can return multiple elements", function () {
             var matches = codeSync.getMatches(stubs, "*", "href");

--- a/test/client-new/code-sync.js
+++ b/test/client-new/code-sync.js
@@ -215,6 +215,20 @@ describe("Code Sync", function () {
             assert.equal(matches[1].id, "stub4");
             assert.equal(matches.length, 2);
         });
+        it("can return only elements matching the same name: 1", function () {
+            stubs.push({
+                id: "stub4",
+                href: "http://localhost:8080/test-style.css"
+            },
+            {
+                id: "stub5",
+                href: "style.css"
+            });
+            var matches = codeSync.getMatches(stubs, "style.css", "href");
+            assert.equal(matches[0].id, "stub1");
+            assert.equal(matches[1].id, "stub5");
+            assert.equal(matches.length, 2);
+        });
     });
     describe("Getting elements", function () {
         it("should return elements + attr", function () {


### PR DESCRIPTION
Improve getMatches so files with similar names are not refreshed. Until now the url matcher only checked for the file name to be contained within the attribute value.
With this change it will not match files with similar names.

### Example:
Saved: `checkout.css`
Links:
  - `http://localhost:8080/checkout.css`
  - `http://localhost:8080/ng-checkout.css`


### Refreshed Before: 
  - `checkout.css`
  - `ng-checkout.css`

### Refreshed After:
  - `checkout.css`