### PR TITLE
Allow to access browserSync instance from a plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,11 @@ exports.init = function (options) {
 
         var browserSync = new BrowserSync(options);
 
+        // Expose browserSync instance to allow runtime extensions
+        BS.use = function (cb) {
+            cb(browserSync);
+        };
+
         // Always init on page load
         ghostMode.init(browserSync);
         codeSync.init(browserSync);

--- a/test/client-new/index.js
+++ b/test/client-new/index.js
@@ -5,6 +5,7 @@ describe("Init method", function(){
     var ghostMode   = window.__bs_ghost_mode__;
     var bs          = window.__bs_stub__;
     var codeSync    = window.__bs_code_sync__;
+    var BrowserSync = window.__bs;
     var notifySpy;
     var notifyFlashSpy;
     var ghostStub;
@@ -16,17 +17,31 @@ describe("Init method", function(){
         ghostStub       = sinon.stub(ghostMode, "init");
         codeSyncStub    = sinon.stub(codeSync, "init");
     });
+    beforeEach(function () {
+        window.___browserSync___ = {};
+    });
+    afterEach(function (){
+        delete window.___browserSync___;
+    });
     after(function () {
         notifySpy.restore();
         notifyFlashSpy.restore();
         ghostStub.restore();
         codeSyncStub.restore();
     });
-    it("should initilize", function(){
+    it("should initialize", function(){
         index.init(bs.options);
         sinon.assert.called(notifySpy);
         sinon.assert.called(notifyFlashSpy);
         sinon.assert.called(ghostStub);
         sinon.assert.called(codeSyncStub);
+    });
+    it("should expose browserSync instance", function(){
+        var spy = sinon.spy();
+        var BS = window.___browserSync___;
+        index.init(bs.options);
+        assert.equal(typeof BS.use === "function", true);
+        BS.use(spy);
+        sinon.assert.calledWith(spy, sinon.match.instanceOf(BrowserSync));
     });
 });


### PR DESCRIPTION
A proposition to address #41 

It exposes a `use(cb)` method which allows to create more sofisticated extensions for browser-sync-client.

```
var myPlugin = function (browserSync) {
    // Do some magic here
}

window.__browserSync__.use(myPlugin)
```